### PR TITLE
Change uplink pattern, change LSM9DS1, BME680 small changes, Extra logging options

### DIFF
--- a/satellite-software/README.md
+++ b/satellite-software/README.md
@@ -141,6 +141,14 @@ The uplink frame count is used by The Things Network to validate the aunthentici
 * **Command Data** : Two bytes interpreted as a `int16_t` in big endian order. This is the uplink frame count that should be set. 
 
 #### LSM9DS1 Commands
+The following variables will be able to be configured for the LSM9DS1 sensor:
+
+| Command Title | Command ID |Command Data | Default Value |
+|:--|:-:|:--|:-:|
+| Acceleration sensitivity setting| `0x00` | One byte containing one of the following enumerations:<br><br>`0x00` - Acceleration sensitivity off<br>`0x01` - Acceleration sensitivity 2g<br>`0x02` - Acceleration sensitivity 4g<br>`0x03` - Acceleration sensitivity 8g<br>`0x04` - Acceleration sensitivity 16g | `0x01` |
+| Gyroscope sensitivity setting| `0x01` | One byte containing one of the following enumerations:<br><br>`0x00` - Gyroscope sensitivity off<br>`0x10` - Gyroscope sensitivity 245 DPS<br>`0x20` - Gyroscope sensitivity 500 DPS<br>`0x40` - Gyroscope sensitivity 2000 DPS | `0x10` |
+| Magnetic sensitivity setting| `0x02` | One byte containing one of the following enumerations:<br><br>`0x00` - Magnetic sensitivity off<br>`0x01` - Magnetic sensitivity 4 Gauss<br>`0x02` - Magnetic sensitivity 8 Gauss<br>`0x03` - Magnetic sensitivity 12 Gauss<br>`0x04` - Magnetic sensitivity 16 Gauss | `0x01` |
+| Set default | `0x03` | Set all LSM9DS1 settings to defaults | N/A |
 
 #### Mission Sensor Commands
 
@@ -155,7 +163,7 @@ The following variables will be able to be configured for the BME680 sensor:
 | Set IIR Filter Coefficient | `0x04` | One byte containing one of the following enumerations:<br><br>`0b000` - coefficient value is 0<br>`0b001` - coefficient value is 1<br>`0b010` - coefficient value is 3<br>`0b011` - coefficient value is 7<br>`0b100` - coefficient value is 15<br>`0b101` - coefficient value is 31<br>`0b101` - coefficient value is 63<br>`0b101` - coefficient value is 127. | `0b010` |
 | Set Gas Heater Heat Time | `0x05` | A two byte `int16` value indicating the amount of time in milliseconds that should be used to heat the gas sensor hot plate. The valid range is between 1 and 4032 milliseconds. | 150 |
 | Set Gas Heater Heat Temperature | `0x06` | A two byte `int16` value indicating the temperature in Celsius that the gas sensor hot plate should be warmed to before making a measurement. The valid range is between 200 °C and 400 °C.  | 320 |
-
+| Set default | `0x07` | Set all BME680 settings to defaults | N/A |
 
 ##### Sensor 6 - Si1132
 The following variables will be able to be configured for the Si1132 sensor:

--- a/satellite-software/include/BME680Sensor.h
+++ b/satellite-software/include/BME680Sensor.h
@@ -8,7 +8,7 @@ class PersistedConfiguration;
 //
 // BME680 Sensor
 //
-#define BME680_I2C_ADDRESS            0x77
+#define BME680_I2C_ADDRESS            0x76
 
 #define BME680_RESULTS_BUFFER_SIZE    18
 

--- a/satellite-software/include/BME680Sensor.h
+++ b/satellite-software/include/BME680Sensor.h
@@ -8,7 +8,7 @@ class PersistedConfiguration;
 //
 // BME680 Sensor
 //
-#define BME680_I2C_ADDRESS            0x76
+#define BME680_I2C_ADDRESS            0x77
 
 #define BME680_RESULTS_BUFFER_SIZE    18
 
@@ -61,6 +61,7 @@ private:
     int32_t calibratedPressureReading(uint8_t press_adc_msb, uint8_t press_adc_lsb, uint8_t press_adc_xlsb, int32_t t_fine);
     int32_t calibratedHumidityReading(uint8_t hum_adc_msb, uint8_t hum_adc_lsb, int32_t temp_comp);
     int32_t calibratedGasResistance(uint8_t gas_adc_msb, uint8_t gas_adc_lsb);
+    void setSensorConfig(void);
     
 protected:
     virtual uint8_t i2cAutoIncrementBit(void) const             { return 0; }

--- a/satellite-software/include/LSM9DS1Sensor.h
+++ b/satellite-software/include/LSM9DS1Sensor.h
@@ -91,6 +91,12 @@ public:
 
     MagneticSensitivitySetting getMagneticSensitivitySetting(void) const            { return _magneticSensitivity; }
     void setMagneticSensitivitySetting(MagneticSensitivitySetting setting);
+
+#ifdef ENABLE_AMBASAT_COMMANDS
+    // handles a command payload. 
+    virtual uint8_t handleCommand(uint16_t cmdSequenceID, uint8_t command, uint8_t* recievedData, uint8_t recievedDataLen);
+
+#endif
 };
 
 #endif

--- a/satellite-software/include/Logging.h
+++ b/satellite-software/include/Logging.h
@@ -5,6 +5,7 @@
 #define LOG_LEVEL_ERRORS  1
 #define LOG_LEVEL_INFO    2
 #define LOG_LEVEL_DEBUG   3
+#define LOG_LEVEL_DEBUG_ONLY   4
 
 #ifndef LOG_LEVEL
 #define LOG_LEVEL LOG_LEVEL_INFO
@@ -51,6 +52,18 @@
 #define PRINT_DEBUG(x)        
 #define PRINT_HEX_DEBUG(x)    
 #define PRINTLN_DEBUG(x)        
+#define PRINT_INFO(x)           
+#define PRINT_HEX_INFO(x)       
+#define PRINTLN_INFO(x)         
+#define PRINT_ERROR(x)          
+#define PRINT_HEX_ERROR(x)      
+#define PRINTLN_ERROR(x)        
+
+#elif LOG_LEVEL == LOG_LEVEL_DEBUG_ONLY
+
+#define PRINT_DEBUG(x)          Serial.print(x)
+#define PRINT_HEX_DEBUG(x)      Serial.print(x, HEX)
+#define PRINTLN_DEBUG(x)        Serial.println(x)
 #define PRINT_INFO(x)           
 #define PRINT_HEX_INFO(x)       
 #define PRINTLN_INFO(x)         

--- a/satellite-software/src/AmbaSat1App.cpp
+++ b/satellite-software/src/AmbaSat1App.cpp
@@ -155,42 +155,42 @@ void AmbaSat1App::loop()
     uint8_t cycles = 3;
     uint8_t system = 2;
 
-    switch(pattern){
+    switch (pattern) {
         case 0x01:
-        system = (uint8_t)_config.getLastPayloadUplinked();
-        if(system == 2) _config.setLastPayloadUplinked((UplinkPayloadType) 0);
-        else _config.setLastPayloadUplinked((UplinkPayloadType) (system+1));
-        break;
+            system = (uint8_t)_config.getLastPayloadUplinked();
+            if (system == 2) _config.setLastPayloadUplinked((UplinkPayloadType) 0);
+            else _config.setLastPayloadUplinked((UplinkPayloadType) (system+1));
+            break;
         case 0x02:
-        system = (uint8_t)_config.getLastPayloadUplinked();
-        cycles = 1;
-        break;
+            system = (uint8_t)_config.getLastPayloadUplinked();
+            cycles = 1;
+            break;
         case 0x03:
-        cycles = 1;
+            cycles = 1;
         break;
     }
 
-    for(uint8_t i = 0; i < cycles; ++i){
-        if(system > 1) system = 0;
+    for (uint8_t i = 0; i < cycles; ++i) {
+        if (system > 1) system = 0;
         else ++system;
 
-        if(system == 0){
+        if (system == 0) {
             PRINTLN_INFO(F("Transmitting Satellite Status."));
             sendSensorPayload(*this);
             _sleeping = false;
-            if(pattern == 0x03){
-                if(_config.getLastPayloadUplinked() == LSM9DS1_PAYLOAD) system = 2;
+            if (pattern == 0x03) {
+                if (_config.getLastPayloadUplinked() == LSM9DS1_PAYLOAD) system = 2;
                 else system = 1;
             }
         }
-        if (system == 1){
+        if (system == 1) {
             if (_lsm9DS1Sensor.isActive()) {
                 PRINTLN_INFO(F("Transmitting LSM9DS1 sensor."));
                 sendSensorPayload(_lsm9DS1Sensor);
                 _sleeping = false;
             }
         }
-        if(system == 2){
+        if (system == 2) {
             if (_missionSensor.isActive()) {
                 PRINTLN_INFO(F("Transmitting mission sensor"));
                 sendSensorPayload(_missionSensor);
@@ -198,7 +198,7 @@ void AmbaSat1App::loop()
             }
         }
         
-        if(pattern > 0x01) _config.setLastPayloadUplinked((UplinkPayloadType) system);        
+        if (pattern > 0x01) _config.setLastPayloadUplinked((UplinkPayloadType) system);        
     } 
     
     //

--- a/satellite-software/src/BME680Sensor.cpp
+++ b/satellite-software/src/BME680Sensor.cpp
@@ -591,6 +591,7 @@ void BME680Sensor::setGasHeatTemperature(int16_t setting, uint8_t profile)
     _gasProfile0_targetTemp = setting;
 }
 
+#ifdef ENABLE_AMBASAT_COMMANDS
 uint8_t BME680Sensor::handleCommand(uint16_t cmdSequenceID, uint8_t command, uint8_t* recievedData, uint8_t recievedDataLen)
 { 
     if ((command >= 0x01)&&(command <= 0x03)) {
@@ -658,16 +659,15 @@ uint8_t BME680Sensor::handleCommand(uint16_t cmdSequenceID, uint8_t command, uin
         PRINT_DEBUG(plate_temp);
         PRINT_DEBUG(F("\n"));
         setGasHeatTemperature(plate_temp);
-    }else if (command == 0x07){
-        PRINT_DEBUG(F("  default "));
-        PRINT_DEBUG(F("\n"));
+    } else if (command == 0x07) {
+        PRINT_DEBUG(F("  default\n"));
         setDefaultValues();
     }
     else { 
         return CMD_STATUS_UNKNOWN_CMD;
     }
-
-    setSensorConfig();
     this->_config.updateCRC();
+    setSensorConfig();
     return CMD_STATUS_SUCCESS;
 }
+#endif

--- a/satellite-software/src/LSM9DS1Sensor.cpp
+++ b/satellite-software/src/LSM9DS1Sensor.cpp
@@ -351,44 +351,44 @@ void LSM9DS1Sensor::setMagneticSensitivitySetting(MagneticSensitivitySetting set
     _magneticSensitivity = setting;
 }
 
+#ifdef ENABLE_AMBASAT_COMMANDS
 uint8_t LSM9DS1Sensor::handleCommand(uint16_t cmdSequenceID, uint8_t command, uint8_t* recievedData, uint8_t recievedDataLen){
-    if(recievedDataLen != 1){
-        return CMD_STATUS_BAD_PARAM;
+    if (recievedDataLen != 1) {
+        return CMD_STATUS_BAD_DATA_LEN;
     }
-    PRINT_DEBUG(F("Change LSM9DS1 settings"));
-    PRINT_DEBUG(F("\n"));
+    PRINT_DEBUG(F("Change LSM9DS1 settings\n"));
     
-    switch(command){
+    switch (command) {
         case 0x00:
-        if(*recievedData > 0x04) return CMD_STATUS_BAD_PARAM;
-        PRINT_DEBUG(F("  Accel setting = "));
-        PRINT_DEBUG(*recievedData);
-        PRINT_DEBUG(F("\n"));
-        setAcceleratonSensitivitySetting((AccelerationSensitivitySetting) *recievedData);        
-        break;
+            if (*recievedData > 0x04) return CMD_STATUS_BAD_PARAM;
+            PRINT_DEBUG(F("  Accel setting = "));
+            PRINT_DEBUG(*recievedData);
+            PRINT_DEBUG(F("\n"));
+            setAcceleratonSensitivitySetting((AccelerationSensitivitySetting) *recievedData);        
+            break;
         case 0x01:
-        if(*recievedData != 0x00 && *recievedData != 0x10 && *recievedData != 0x20 && *recievedData != 0x40) return CMD_STATUS_BAD_PARAM;
-        PRINT_DEBUG(F("  Gyro setting = "));
-        PRINT_DEBUG(*recievedData);
-        PRINT_DEBUG(F("\n"));
-        setGysroSensitivitySetting((GyroSensitivitySetting)*recievedData);
-        break;
+            if ( (*recievedData)&0x8F != 0 ) return CMD_STATUS_BAD_PARAM;
+            PRINT_DEBUG(F("  Gyro setting = "));
+            PRINT_DEBUG(*recievedData);
+            PRINT_DEBUG(F("\n"));
+            setGysroSensitivitySetting((GyroSensitivitySetting)*recievedData);
+            break;
         case 0x02:
-        if(*recievedData > 0x04) return CMD_STATUS_BAD_PARAM;
-        PRINT_DEBUG(F("  Magn setting = "));
-        PRINT_DEBUG(*recievedData);
-        PRINT_DEBUG(F("\n"));
-        setMagneticSensitivitySetting((MagneticSensitivitySetting) *recievedData);
-        break;
+            if (*recievedData > 0x04) return CMD_STATUS_BAD_PARAM;
+            PRINT_DEBUG(F("  Magn setting = "));
+            PRINT_DEBUG(*recievedData);
+            PRINT_DEBUG(F("\n"));
+            setMagneticSensitivitySetting((MagneticSensitivitySetting) *recievedData);
+            break;
         case 0x03:
-        PRINT_DEBUG(F("  Set defaults "));
-        PRINT_DEBUG(F("\n"));
-        setDefaultValues();
-        break;
+            PRINT_DEBUG(F("  Set defaults\n"));
+            setDefaultValues();
+            break;
         default:
-        return CMD_STATUS_BAD_PARAM;
+            return CMD_STATUS_BAD_PARAM;
     }
-    setSensorConfig(); //cement the changes.
     this->_config.updateCRC();
+    setSensorConfig(); //cement the changes.    
     return CMD_STATUS_SUCCESS;
 }
+#endif

--- a/satellite-software/src/LSM9DS1Sensor.cpp
+++ b/satellite-software/src/LSM9DS1Sensor.cpp
@@ -350,3 +350,45 @@ void LSM9DS1Sensor::setMagneticSensitivitySetting(MagneticSensitivitySetting set
     eeprom_update_byte((uint8_t *)(getEEPROMBaseAddress()+OFFSET_MAGNETIC_SENSITIVITY), setting);
     _magneticSensitivity = setting;
 }
+
+uint8_t LSM9DS1Sensor::handleCommand(uint16_t cmdSequenceID, uint8_t command, uint8_t* recievedData, uint8_t recievedDataLen){
+    if(recievedDataLen != 1){
+        return CMD_STATUS_BAD_PARAM;
+    }
+    PRINT_DEBUG(F("Change LSM9DS1 settings"));
+    PRINT_DEBUG(F("\n"));
+    
+    switch(command){
+        case 0x00:
+        if(*recievedData > 0x04) return CMD_STATUS_BAD_PARAM;
+        PRINT_DEBUG(F("  Accel setting = "));
+        PRINT_DEBUG(*recievedData);
+        PRINT_DEBUG(F("\n"));
+        setAcceleratonSensitivitySetting((AccelerationSensitivitySetting) *recievedData);        
+        break;
+        case 0x01:
+        if(*recievedData != 0x00 && *recievedData != 0x10 && *recievedData != 0x20 && *recievedData != 0x40) return CMD_STATUS_BAD_PARAM;
+        PRINT_DEBUG(F("  Gyro setting = "));
+        PRINT_DEBUG(*recievedData);
+        PRINT_DEBUG(F("\n"));
+        setGysroSensitivitySetting((GyroSensitivitySetting)*recievedData);
+        break;
+        case 0x02:
+        if(*recievedData > 0x04) return CMD_STATUS_BAD_PARAM;
+        PRINT_DEBUG(F("  Magn setting = "));
+        PRINT_DEBUG(*recievedData);
+        PRINT_DEBUG(F("\n"));
+        setMagneticSensitivitySetting((MagneticSensitivitySetting) *recievedData);
+        break;
+        case 0x03:
+        PRINT_DEBUG(F("  Set defaults "));
+        PRINT_DEBUG(F("\n"));
+        setDefaultValues();
+        break;
+        default:
+        return CMD_STATUS_BAD_PARAM;
+    }
+    setSensorConfig(); //cement the changes.
+    this->_config.updateCRC();
+    return CMD_STATUS_SUCCESS;
+}


### PR DESCRIPTION
The changes that are in this pull request are:

1) Change uplink pattern by downlinks according to the satellite-software README.md.
2) Added ability to change LSM9DS1 settings by downlinks.
3) BME680: I added a downlink command to reset BME680 to defaults. And I changed the software to accomodate a setSensorConfig() function. The reason for this has to do with downlinks. During testing of the LSM9DS1 downlinks I noticed that I had to call the setSensorConfig() function to set the changes (write to the registers of the sensor). However, this was not quite clear with the BME680 sensor as the changes due to different settings (of the ranges) do not influence the readings that much (in the controlled environment of my room). I do think that similarly, to set the changes this setSensorConfig() function has to be called. However, this would actually be something that needs to be tested more (as of now I do see small changes when I call or do not call this function which are in favor of doing it like implemented here).
4) This has more to do with the memory size. I added a new logging level (LOG_LEVEL_DEBUG_ONLY) which only shows the debug messages. Next to that, I shortened some of the debug messages (you would think this does not matter, yet I saved 0.2% this way). When using the BME680 sensor with some debug messages, the memory size of this program is very close to 100%, these changes made it slightly smaller (99,6%).

One final message would be that I tested these changes, but not to the level that I would need to be confident. I will resume testing shortly, but I have a publication due very soon which will take all my time this week.